### PR TITLE
Return value of update() changed;

### DIFF
--- a/NTP.cpp
+++ b/NTP.cpp
@@ -49,7 +49,7 @@ bool NTP::update() {
   if ((millis() - lastUpdate >= interval) || lastUpdate == 0) {
     return ntpUpdate();
     }
-  return true;
+  return false;
   }
 
 bool NTP::ntpUpdate() {

--- a/NTP.h
+++ b/NTP.h
@@ -73,7 +73,7 @@ class NTP {
      * made every 60 seconds. This can be configured in the NTPTime constructor.
      * 
      * @return true on success
-     * @return false on failure
+     * @return false on no update or update failure
      */
     bool update();
 


### PR DESCRIPTION
You might consider to change the return value in update() method to false if the update interval is not reached. This way the user can determine in the main loop, when/if the time has really been updated.

e.g. in my use case, I can compare the NTP time with RTC and update the RTC if needed, when update() returns true (only) - without other workarounds.

BR
morres