### PR TITLE
begin() blocks if there is no internet connection

### DIFF
--- a/NTP.cpp
+++ b/NTP.cpp
@@ -30,9 +30,12 @@ NTP::~NTP() {
   stop();
   }
 
-void NTP::begin() {
+void NTP::begin(bool blocking) {
   udp->begin(NTP_DEFAULT_LOCAL_PORT);
-  while (!ntpUpdate());
+  
+  if (blocking) while (!ntpUpdate());
+  else ntpUpdate();
+
   if (dstZone) {
     timezoneOffset = dstEnd.tzOffset * SECS_PER_MINUTES;
     dstOffset = (dstStart.tzOffset - dstEnd.tzOffset) * SECS_PER_MINUTES;

--- a/NTP.h
+++ b/NTP.h
@@ -59,8 +59,9 @@ class NTP {
     /**
      * @brief starts the underlying UDP client with the default local port
      * 
+     * @param blocking function blocks until answer from NTP server is reached
      */
-    void begin();
+    void begin(bool blocking = true);
 
     /**
      * @brief stops the underlying UDP client


### PR DESCRIPTION
If there is no internet connection or the NTP server cannot be reached, begin() will block forever. In some cases, the correct time might not be crucial for program execution. Therefore, begin() can be equipped with a parameter, which tells if  begin() shall be blocking or not.

The default value is "true" for backwards compatibility.