### PR TITLE
Set system time

### DIFF
--- a/NTP.cpp
+++ b/NTP.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "NTP.h"
+#include <time.h>
 
 NTP::NTP(UDP& udp) {
 	this->udp = &udp;
@@ -104,6 +105,11 @@ bool NTP::ntpUpdate() {
 			}
 		else return false;
  	#endif
+
+	// set the hardware clock to UTC
+	timeval tv = { epoch(), 0 };
+	settimeofday(&tv, nullptr);
+
 	return true;
 	}
 

--- a/examples/CheckSystemClock/CheckSystemClock.ino
+++ b/examples/CheckSystemClock/CheckSystemClock.ino
@@ -1,0 +1,46 @@
+// example for WIFI based boards like ESP8266, ESP32, Nano RP2040 Connect, WiFi 101 shield or MKR1000
+
+#include "Arduino.h"
+// change next line to use with another board/shield
+#include <ESP8266WiFi.h>
+//#include <WiFi.h> // for WiFi shield or ESP32
+//#include <WiFi101.h> // for WiFi 101 shield or MKR1000
+//#include <WiFiNINA.h> // for e.g. Nano RP2040 Connect
+#include "WiFiUdp.h" // not needed for WiFiNINA
+#include "NTP.h"
+
+char ssid[]     = "yourSSID";
+char password[] = "yourPASSWORD";
+
+WiFiUDP wifiUdp;
+NTP ntp(wifiUdp);
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    Serial.println("Connecting ...");
+    delay(500);
+    }
+  Serial.println("Connected");
+  ntp.ruleDST("CEST", Last, Sun, Mar, 2, 120); // last sunday in march 2:00, timetone +120min (+1 GMT + 1h summertime offset)
+  ntp.ruleSTD("CET", Last, Sun, Oct, 3, 60); // last sunday in october 3:00, timezone +60min (+1 GMT)
+  ntp.begin();
+  Serial.println("start NTP");
+  }
+
+void loop() {
+  ntp.update();
+  Serial.println(ntp.formattedTime("%d. %B %Y")); // dd. Mmm yyyy
+  Serial.println(ntp.formattedTime("%A %T")); // Www hh:mm:ss
+
+  // Because the system clock was updated we can use the standard time() function to obtain UTC time.
+  time_t now = time(NULL);
+  char *systemtime = (char *)"System Clock Not Set";
+  if (now > 3600)
+    systemtime = ctime(&now);
+  Serial.print("System Clock (UTC): ");
+  Serial.println(systemtime);
+
+  delay(1000);
+  }


### PR DESCRIPTION
This branch adds setting the hardware clock with `setttimeofday()`, such that standard time() functions will work; at least to return UTC time.  It felt to me like that should be part of such a library rather than leaving it up to the caller to research/realize this is needed, but some may have different opinion.

I was only able to test this on esp8266 at this time, I don't have any reference if this works on other hardware.

Perhaps this should be made optional step, but for me doing this in the `ntpUpdate()` call works for my use case.  (I was using the `TLog` to log message via syslog and it expects time() to work.)

I suppose if it was optional, some might want this to set hardware to localtime; since it happens frequently enough I suppose that'd be good enough for DST changes.