### PR TITLE
Populate transmit timestamp in request and verify the originate timestamp in the response matches.

### DIFF
--- a/NTP.h
+++ b/NTP.h
@@ -249,8 +249,8 @@ class NTP {
     UDP *udp;
     const char* server = nullptr;
     IPAddress serverIP;
-    uint8_t ntpRequest[NTP_PACKET_SIZE]; // = {0xE3, 0x00, 0x06, 0xEC};
-    uint8_t ntpQuery[NTP_PACKET_SIZE];
+    uint8_t ntpRequest[NTP_PACKET_SIZE] __attribute__((aligned(4))); // = {0xE3, 0x00, 0x06, 0xEC};
+    uint8_t ntpQuery[NTP_PACKET_SIZE] __attribute__((aligned(4)));
     time_t utcCurrent = 0;
     time_t local = 0;
     struct tm *current;


### PR DESCRIPTION
This fixes the case where we end up reading a previous response packet, whose timestamp may now be out of date by the update interval (e.g. 60 sec)

A state of receiving the previous response packet can persist for very long periods (because we send a new packet at each update that will then be received - late - at the next update, and so on until a response packet is actually lost).